### PR TITLE
fix(mce): Only allow exact map name match

### DIFF
--- a/addons/sourcemod/scripting/include/mapchooser_extended.inc
+++ b/addons/sourcemod/scripting/include/mapchooser_extended.inc
@@ -41,7 +41,7 @@
 
 #define MCE_V_MAJOR "1"
 #define MCE_V_MINOR "13"
-#define MCE_V_PATCH "1"
+#define MCE_V_PATCH "2"
 
 #define MCE_VERSION MCE_V_MAJOR..."."...MCE_V_MINOR..."."...MCE_V_PATCH
 

--- a/addons/sourcemod/scripting/mce/commands.inc
+++ b/addons/sourcemod/scripting/mce/commands.inc
@@ -44,7 +44,7 @@ public Action Command_SetNextmap(int client, int args)
 	static char map[PLATFORM_MAX_PATH];
 	GetCmdArg(1, map, PLATFORM_MAX_PATH);
 
-	if (!IsMapValid(map))
+	if (!IsMapValidEx(map))
 	{
 		CReplyToCommand(client, "{green}[MCE]{default} %t", "Map was not found", map);
 		return Plugin_Handled;

--- a/addons/sourcemod/scripting/mce/internal_functions.inc
+++ b/addons/sourcemod/scripting/mce/internal_functions.inc
@@ -11,7 +11,7 @@
 
 NominateResult InternalNominateMap(char[] map, bool force, int owner)
 {
-	if (!IsMapValid(map))
+	if (!IsMapValidEx(map))
 	{
 		return Nominate_InvalidMap;
 	}
@@ -732,4 +732,11 @@ stock void InternalShowMapGroups(int client, const char[] map)
 
 	PrintToConsole(client, "%s is in %d groups", map, count);
 	PrintToConsole(client, "-----------------------------------------");
+}
+
+stock bool IsMapValidEx(const char[] map)
+{
+	char displayName[PLATFORM_MAX_PATH];
+	FindMapResult result = FindMap(map, displayName, sizeof(displayName));
+	return (result == FindMap_Found);
 }

--- a/addons/sourcemod/scripting/mce/menus.inc
+++ b/addons/sourcemod/scripting/mce/menus.inc
@@ -246,7 +246,7 @@ void InitiateVote(MapChange when, Handle inputlist=INVALID_HANDLE)
 		{
 			GetArrayString(inputlist, i, map, PLATFORM_MAX_PATH);
 
-			if (IsMapValid(map))
+			if (IsMapValidEx(map))
 			{
 				FormatEx(allMapsBuffer, allMapsSize, "%s\n- %s", allMapsBuffer, map);
 				AddMapItem(map);


### PR DESCRIPTION
This PR improves the map validation process by implementing a stricter validation method that only allows exact map name matches. The previous implementation used `IsMapValid()` which could match partial map names, potentially leading to incorrect map selections.

## Changes
- Added a new `IsMapValidEx()` function that uses `FindMap()` with `FindMap_Found` result checking to ensure only exact matches are accepted
- Updated all map validation checks throughout the codebase to use the new function
- Incremented version patch number from 1.13.1 to 1.13.2

## Why This Change Is Needed
This fix prevents potential issues where partial map name matches could lead to incorrect map selections or nominations, ensuring that only maps with exact matching names are considered valid.

Example with folder `/maps` have `de_dust2` only:
- `IsMapValid` the input `de_dust` will be considered as valid (FuzzyMatch)
- `IsMapValidEx` it will return map not found