### PR TITLE
feat(MCE): Groups Cooldown time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Advanced Automated Map Voting with Extensions
             "_name" "Final Fantasy" // Group name (Optional) 
             "_max" "1" // Maximum 1 consecutive map from this group
             "_cooldown" "10" // Shared cooldown mode to all these maps (cvar: mce_sharedcd_mode)
+            "_cooldown_time" "60" // Same as `"CooldownTime"` but this is for groups. Supported formats: "30m", "2h", "1h30m", "2h15m30s", "60" (defaults to minutes)
             "ze_ffvii_mako_reactor_v2_2" {}
             "ze_ffvii_mako_reactor_v3_1" {}
             "ze_ffvii_mako_reactor_v5_3" {}
@@ -21,9 +22,10 @@ Advanced Automated Map Voting with Extensions
         }
         "2" // wanderers
         {
-            "_name" "Wanderers marathon" // Group name (Optional) 
-            "_max" "2" // Maximum 2 consecutive maps from this group
-            "_cooldown" "44" // Shared cooldown mode to all these maps (cvar: mce_sharedcd_mode)
+            "_name" "Wanderers marathon"
+            "_max" "2"
+            "_cooldown" "44"
+            "_cooldown_time" "12h"
             "ze_ffxiv_wanderers_palace_css" {}
             "ze_ffxiv_wanderers_palace_v4_5s" {}
             "ze_ffxiv_wanderers_palace_v5_2f" {}

--- a/addons/sourcemod/configs/mapchooser_extended.cfg
+++ b/addons/sourcemod/configs/mapchooser_extended.cfg
@@ -5,6 +5,7 @@
 		"1" // final fantasy
 		{
 			"_max" "2"
+			"_cooldown_time" "60"
 			"ze_ffvii_cosmo_canyon_v1_1" {}
 			"ze_ffvii_cosmo_canyon_v5fix" {}
 			"ze_ffvii_mako_reactor_v2_2" {}

--- a/addons/sourcemod/scripting/include/mapchooser_extended.inc
+++ b/addons/sourcemod/scripting/include/mapchooser_extended.inc
@@ -41,7 +41,7 @@
 
 #define MCE_V_MAJOR "1"
 #define MCE_V_MINOR "13"
-#define MCE_V_PATCH "4"
+#define MCE_V_PATCH "5"
 
 #define MCE_VERSION MCE_V_MAJOR..."."...MCE_V_MINOR..."."...MCE_V_PATCH
 

--- a/addons/sourcemod/scripting/mce/functions.inc
+++ b/addons/sourcemod/scripting/mce/functions.inc
@@ -83,45 +83,23 @@ stock void InitializeGroupSettings()
 	GetCurrentMap(sCurrentMap, sizeof(sCurrentMap));
 
 	int groups[32];
-	int iDefaultGrpCooldown = -1;
 	int iTotalGrpFound = InternalGetMapGroups(sCurrentMap, groups, sizeof(groups));
-
-	bool bValidCooldownFound = false;
-	bool bCooldownMatching = true;
 
 	for (int i = 0; i < iTotalGrpFound; ++i)
 	{
 		int groupID = groups[i];
 		int iGrpCooldown = InternalGetGroupCooldown(groupID);
+		int iGrpCooldownTime = InternalGetGroupCooldownTime(groupID);
 
-		if (iGrpCooldown >= 0)
+		if (iGrpCooldownTime > 0)
 		{
-			if (!bValidCooldownFound) // First valid cooldown found
-			{
-				iDefaultGrpCooldown = iGrpCooldown;
-				bValidCooldownFound = true;
-			}
-			else if (iDefaultGrpCooldown != iGrpCooldown) // Found a different cooldown value in another group
-			{
-				bCooldownMatching = false;
-				LogMessage("Map %s is in multiple groups with different cooldowns. No shared cooldown will be applied.", sCurrentMap);
-				return;
-			}
+			LogMessage("Map %s is in group %d with time-based cooldown of %d seconds", sCurrentMap, groupID, iGrpCooldownTime);
+			InternalSetGroupCooldownToMaps(groupID, iGrpCooldown);
 		}
-	}
-
-	if (bValidCooldownFound && bCooldownMatching)
-	{
-		LogMessage("Map %s is in multiple groups with matching cooldowns. Applying shared cooldown to all maps in these groups.", sCurrentMap);
-		// Apply the cooldown to all maps in groups with a matching cooldown
-		for (int i = 0; i < iTotalGrpFound; ++i)
+		else if (iGrpCooldown >= 0)
 		{
-			int groupID = groups[i];
-			if (InternalGetGroupCooldown(groupID) == -1) // No cooldown configured for this group
-				continue;
-
-			InternalSetGroupCooldownToMaps(groupID, iDefaultGrpCooldown);
-			LogMessage("Applied shared cooldown to maps in group \"%d\".", groupID);
+			LogMessage("Map %s is in group %d with counter-based cooldown of %d", sCurrentMap, groupID, iGrpCooldown);
+			InternalSetGroupCooldownToMaps(groupID, iGrpCooldown);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/mce/internal_functions.inc
+++ b/addons/sourcemod/scripting/mce/internal_functions.inc
@@ -394,6 +394,27 @@ stock int InternalGetGroupCooldown(int group)
 	return -1;
 }
 
+stock int InternalGetGroupCooldownTime(int group)
+{
+	char groupstr[8];
+	IntToString(group, groupstr, sizeof(groupstr));
+	if (g_Config && g_Config.JumpToKey("_groups"))
+	{
+		if (g_Config.JumpToKey(groupstr, false))
+		{
+			char time[16];
+			g_Config.GetString("_cooldown_time", time, sizeof(time), "");
+			if (time[0])
+			{
+				g_Config.Rewind();
+				return TimeStrToSeconds(time);
+			}
+			g_Config.Rewind();
+		}
+	}
+	return 0;
+}
+
 stock void InternalSetGroupCooldownToMaps(int group, int cooldown)
 {
 	if (g_Config && g_Config.JumpToKey("_groups"))
@@ -413,9 +434,18 @@ stock void InternalSetGroupCooldownToMaps(int group, int cooldown)
 				char map[PLATFORM_MAX_PATH];
 				g_Config.GetSectionName(map, sizeof(map));
 				if (strncmp(map, "_", 1) == 0) // Skip: All groups settings, always starting with "_"
-                    continue;
+					continue;
 
-				ExcludeMap(map, cooldown, g_iSharedCDMode);
+				// Use time-based cooldown instead of counter-based
+				int cooldownTime = InternalGetGroupCooldownTime(group);
+				if (cooldownTime > 0)
+				{
+					ExcludeMapTime(map, cooldownTime, g_iSharedCDMode);
+				}
+				else
+				{
+					ExcludeMap(map, cooldown, g_iSharedCDMode);
+				}
 			}
 			while (g_Config.GotoNextKey());
 
@@ -717,6 +747,8 @@ stock void InternalShowMapGroups(int client, const char[] map)
 
 		int max = g_Config.GetNum("_max", -1);
 		int cd = g_Config.GetNum("_cooldown", -1);
+		char time[16];
+		g_Config.GetString("_cooldown_time", time, sizeof(time), "");
 
 		if (max > 0)
 		{
@@ -725,6 +757,10 @@ stock void InternalShowMapGroups(int client, const char[] map)
 		if (cd > 0)
 		{
 			PrintToConsole(client, "[%03d] Group Cooldown: %d", count, cd);
+		}
+		if (time[0])
+		{
+			PrintToConsole(client, "[%03d] Group Time Cooldown: %s", count, time);
 		}
 		PrintToConsole(client, "-----------------------------------");
 	}


### PR DESCRIPTION
## Add time-based cooldown support for map groups

### Changes
- Added `_cooldown_time` key to map groups configuration
- Supports flexible time formats: `"30m"`, `"2h"`, `"1h30m"`, `"2h15m30s"`, `"60"` (defaults to minutes)
- Time-based cooldowns take priority over counter-based cooldowns when both are defined
- Uses `TimeStrToSeconds()` function to parse time strings into seconds
- Automatically applies time cooldown to all maps within a group

### Usage
```cfg
"_groups"
{
    "1"
    {
        "_name"             "Competitive Maps"
        "_cooldown_time"    "2h30m"    // 2 hours 30 minutes
        "_max"              "3"
        
        "de_dust2"          {}
        "de_mirage"         {}
    }
}
```

### Benefits
- More precise cooldown control compared to vote-based cooldowns
- Prevents map spam regardless of vote frequency
- Flexible time formatting for easy configuration