### PR TITLE
feat(mce): map description and display name

### DIFF
--- a/addons/sourcemod/scripting/include/mapchooser_extended.inc
+++ b/addons/sourcemod/scripting/include/mapchooser_extended.inc
@@ -41,7 +41,7 @@
 
 #define MCE_V_MAJOR "1"
 #define MCE_V_MINOR "13"
-#define MCE_V_PATCH "7"
+#define MCE_V_PATCH "8"
 
 #define MCE_VERSION MCE_V_MAJOR..."."...MCE_V_MINOR..."."...MCE_V_PATCH
 
@@ -334,6 +334,26 @@ native bool AreRestrictionsActive();
  * @noreturn
  */
 native int SimulateMapEnd();
+
+/**
+ * Get the description for a map
+ *
+ * @param map      Name of map
+ * @param buffer   Buffer to store description
+ * @param maxlen   Maximum length of buffer
+ * @return         true if description exists, false otherwise
+ */
+native bool MCE_GetMapDescription(const char[] map, char[] buffer, int maxlen);
+
+/**
+ * Get the display name for a map
+ *
+ * @param map      Name of map
+ * @param buffer   Buffer to store display name
+ * @param maxlen   Maximum length of buffer
+ * @return         true if display name exists, false otherwise (if false, the original map name is stored in buffer)
+ */
+native bool MCE_GetMapDisplayName(const char[] map, char[] buffer, int maxlen);
 
 public SharedPlugin __pl_mapchooser_extended =
 {

--- a/addons/sourcemod/scripting/include/nominations_extended.inc
+++ b/addons/sourcemod/scripting/include/nominations_extended.inc
@@ -5,7 +5,7 @@
 
 #define NE_V_MAJOR "1"
 #define NE_V_MINOR "12"
-#define NE_V_PATCH "11"
+#define NE_V_PATCH "12"
 
 #define NE_VERSION NE_V_MAJOR..."."...NE_V_MINOR..."."...NE_V_PATCH
 

--- a/addons/sourcemod/scripting/mce/commands.inc
+++ b/addons/sourcemod/scripting/mce/commands.inc
@@ -82,6 +82,7 @@ public Action Command_ShowConfig(int client, int args)
 		}
 	}
 
+	char desc[128], displayName[PLATFORM_MAX_PATH], formattedName[PLATFORM_MAX_PATH];
 	int extends = InternalGetMapMaxExtends(map);
 	int extendtime = InternalGetMapExtendTime(map);
 	int extendround = InternalGetMapExtendRound(map);
@@ -95,14 +96,15 @@ public Action Command_ShowConfig(int client, int args)
 	bool adminonly = InternalGetMapAdminRestriction(map);
 	bool viponly = InternalGetMapVIPRestriction(map);
 	bool leaderonly = InternalGetMapLeaderRestriction(map);
-	// char desc[MAX_DESCRIPTION_LENGTH];
-	// bool descr = InternalGetMapDescription(map, desc, sizeof(desc));
+	bool descr = InternalGetMapDescription(map, desc, sizeof(desc));
+	bool hasDisplayName = InternalGetMapDisplayName(map, displayName, sizeof(displayName));
+	InternalFormatMapDisplay(map, formattedName, sizeof(formattedName), client, false);
 
 	if (GetCmdReplySource() == SM_REPLY_TO_CHAT)
 	{
 		CPrintToChat(client, "{green}[MCE]{default} %t", "See console for output");
 	}
-	
+
 	PrintToConsole(client, "-----------------------------------------");
 	PrintToConsole(client, "Showing config info for: %s", map);
 	PrintToConsole(client, "-----------------------------------------");
@@ -119,7 +121,9 @@ public Action Command_ShowConfig(int client, int args)
 	PrintToConsole(client, "%-15s %5b", "Admin Only: ", adminonly);
 	PrintToConsole(client, "%-15s %5b", "VIP Only: ", viponly);
 	PrintToConsole(client, "%-15s %5b", "Leader Only: ", leaderonly);
-	// PrintToConsole(client, "%-15s %5s %s", "Description: ", descr?"Yes:":"No", desc);
+	PrintToConsole(client, "%-15s %s", "Display Name: ", hasDisplayName ? displayName : "None");
+	PrintToConsole(client, "%-15s %s", "Description: ", descr ? desc : "None");
+	PrintToConsole(client, "%-15s %s", "Menu Display: ", formattedName);
 	PrintToConsole(client, "-----------------------------------------");
 	InternalShowMapGroups(client, map);
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/mce/internal_functions.inc
+++ b/addons/sourcemod/scripting/mce/internal_functions.inc
@@ -590,6 +590,124 @@ stock bool InternalGetMapLeaderRestriction(const char[] map)
 	return view_as<bool>(Leader);
 }
 
+stock bool InternalGetMapDescription(const char[] map, char[] buffer, int maxlen)
+{
+	if (!g_Config)
+		return false;
+
+	g_Config.Rewind();
+	if (!g_Config.JumpToKey(map))
+		return false;
+
+	g_Config.GetString("Description", buffer, maxlen);
+	if (!buffer[0])
+		return false;
+
+	return true;
+}
+
+stock bool InternalGetMapDisplayName(const char[] map, char[] buffer, int maxlen)
+{
+	if (!g_Config)
+		return false;
+
+	g_Config.Rewind();
+	if (!g_Config.JumpToKey(map))
+		return false;
+
+	g_Config.GetString("DisplayName", buffer, maxlen);
+	if (!buffer[0])
+		return false;
+
+	return true;
+}
+
+stock void InternalGetMapStatusBadges(const char[] map, char[] buffer, int maxlen, int client)
+{
+	char badges[128];
+
+	InternalGetMapStatusBadge_Leader(map, badges, sizeof(badges), client);
+	InternalGetMapStatusBadge_Admin(map, badges, sizeof(badges), client);
+	InternalGetMapStatusBadge_VIP(map, badges, sizeof(badges), client);
+
+	// Remove trailing |
+	int len = strlen(badges);
+	if (len > 0 && badges[len-1] == '|')
+	{
+		badges[len-1] = '\0';
+	}
+
+	Format(buffer, maxlen, "%s", badges);
+}
+
+stock void InternalGetMapStatusBadge_Leader(const char[] map, char[] buffer, int maxlen, int client)
+{
+	if (InternalGetMapLeaderRestriction(map))
+	{
+		Format(buffer, maxlen, "%s%T|", buffer, "Leader Restriction", client);
+	}
+}
+
+stock void InternalGetMapStatusBadge_Admin(const char[] map, char[] buffer, int maxlen, int client)
+{
+	if (InternalGetMapAdminRestriction(map))
+	{
+		Format(buffer, maxlen, "%s%T|", buffer, "Admin Restriction", client);
+	}
+}
+
+stock void InternalGetMapStatusBadge_VIP(const char[] map, char[] buffer, int maxlen, int client)
+{
+	if (InternalGetMapVIPRestriction(map))
+	{
+		Format(buffer, maxlen, "%s%T|", buffer, "VIP Restriction", client);
+	}
+}
+
+stock void InternalFormatMapDisplay(const char[] map, char[] buffer, int maxlen, int client, bool includeBadges = true)
+{
+	char displayName[PLATFORM_MAX_PATH];
+	char cleanName[PLATFORM_MAX_PATH];
+	char badges[128];
+	char description[128];
+
+	// Get display name or use original map name
+	if (InternalGetMapDisplayName(map, displayName, sizeof(displayName)))
+	{
+		strcopy(cleanName, sizeof(cleanName), displayName);
+	}
+	else
+	{
+		strcopy(cleanName, sizeof(cleanName), map);
+	}
+
+	// Get status badges
+	if (includeBadges)
+	{
+		InternalGetMapStatusBadges(map, badges, sizeof(badges), client);
+	}
+
+	// Get description if available
+	bool hasDescription = InternalGetMapDescription(map, description, sizeof(description));
+
+	if (hasDescription && badges[0] != '\0')
+	{
+		Format(buffer, maxlen, "%s [%s | %s]", cleanName, badges, description);
+	}
+	else if (badges[0] != '\0')
+	{
+		Format(buffer, maxlen, "%s [%s]", cleanName, badges);
+	}
+	else if (hasDescription)
+	{
+		Format(buffer, maxlen, "%s [%s]", cleanName, description);
+	}
+	else
+	{
+		strcopy(buffer, maxlen, cleanName);
+	}
+}
+
 stock void InternalRestoreMapCooldowns()
 {
 	char sCooldownFile[PLATFORM_MAX_PATH];
@@ -784,10 +902,4 @@ stock bool IsMapValidEx(const char[] map)
 	char displayName[PLATFORM_MAX_PATH];
 	FindMapResult result = FindMap(map, displayName, sizeof(displayName));
 	return (result == FindMap_Found);
-}
-
-public Action Timer_DelayedTimeleftCheck(Handle timer)
-{
-	SetupTimeleftTimer();
-	return Plugin_Stop;
 }

--- a/addons/sourcemod/scripting/mce/menus.inc
+++ b/addons/sourcemod/scripting/mce/menus.inc
@@ -567,21 +567,22 @@ public int Handler_MapVoteMenu(Handle menu, MenuAction action, int param1, int p
 			// Note that the first part is to discard the spacer line
 			else if (strcmp(map, LINE_SPACER, false) != 0)
 			{
+				char formattedDisplay[PLATFORM_MAX_PATH];
+				InternalFormatMapDisplay(map, formattedDisplay, sizeof(formattedDisplay), param1, false);
+
+				// Handle custom map markings
 				if (g_iMarkCustomMaps == 1 && !InternalIsMapOfficial(map))
 				{
-					Format(buffer, sizeof(buffer), "%T", "Custom Marked", param1, map);
+					Format(buffer, sizeof(buffer), "%T", "Custom Marked", param1, formattedDisplay);
 				}
 				else if (g_iMarkCustomMaps == 2 && !InternalIsMapOfficial(map))
 				{
-					Format(buffer, sizeof(buffer), "%T", "Custom", param1, map);
+					Format(buffer, sizeof(buffer), "%T", "Custom", param1, formattedDisplay);
 				}
-				else if (InternalGetMapVIPRestriction(map))
+				else
 				{
-					Format(buffer, sizeof(buffer), "%s (%T)", map, "VIP Nomination", param1);
-				}
-				else if (InternalGetMapLeaderRestriction(map))
-				{
-					Format(buffer, sizeof(buffer), "%s (%T)", map, "Leader Nomination", param1);
+					// Use the formatted display as-is
+					strcopy(buffer, sizeof(buffer), formattedDisplay);
 				}
 			}
 

--- a/addons/sourcemod/scripting/mce/natives.inc
+++ b/addons/sourcemod/scripting/mce/natives.inc
@@ -52,6 +52,8 @@ stock void API_NativesInit()
 	CreateNative("GetMapExtendFrags", Native_GetMapExtendFrag);
 	CreateNative("AreRestrictionsActive", Native_AreRestrictionsActive);
 	CreateNative("SimulateMapEnd", Native_SimulateMapEnd);
+	CreateNative("MCE_GetMapDescription", Native_GetMapDescription);
+	CreateNative("MCE_GetMapDisplayName", Native_GetMapDisplayName);
 }
 
 /* Add natives to allow nominate and initiate vote to be call */
@@ -702,4 +704,44 @@ public int Native_SimulateMapEnd(Handle plugin, int numParams)
 {
 	OnMapEnd();
 	return 0;
+}
+
+public int Native_GetMapDescription(Handle plugin, int numParams)
+{
+	int len;
+	GetNativeStringLength(1, len);
+	if (len <= 0)
+		return false;
+
+	char[] map = new char[len+1];
+	GetNativeString(1, map, len+1);
+
+	len = GetNativeCell(3);
+	char[] buffer = new char[len];
+	bool result = InternalGetMapDescription(map, buffer, len);
+
+	SetNativeString(2, buffer, len);
+	return result;
+}
+
+public int Native_GetMapDisplayName(Handle plugin, int numParams)
+{
+	int len;
+	GetNativeStringLength(1, len);
+	if (len <= 0)
+		return false;
+
+	char[] map = new char[len+1];
+	GetNativeString(1, map, len+1);
+
+	len = GetNativeCell(3);
+	char[] buffer = new char[len];
+	bool result = InternalGetMapDisplayName(map, buffer, len);
+
+	// If the map display name is not found, use the original map name
+	if (!result)
+		strcopy(buffer, len, map);
+
+	SetNativeString(2, buffer, len);
+	return result;
 }

--- a/addons/sourcemod/scripting/ne/menus.inc
+++ b/addons/sourcemod/scripting/ne/menus.inc
@@ -676,9 +676,9 @@ bool FormatMapRestrictionBadgesDetailed(const char[] map, int client, char[] buf
 			if (playerRestriction != 0)
 			{
 				if (playerRestriction < 0)
-						Format(badges, sizeof(badges), "%s%T|", buffer, "Map Player Restriction", client, "+", playerRestriction * -1);
+						Format(badges, sizeof(badges), "%s%T|", badges, "Map Player Restriction", client, "+", playerRestriction * -1);
 					else
-						Format(badges, sizeof(badges), "%s%T|", buffer, "Map Player Restriction", client, "-", playerRestriction);
+						Format(badges, sizeof(badges), "%s%T|", badges, "Map Player Restriction", client, "-", playerRestriction);
 				hasBadges = true;
 			}
 

--- a/addons/sourcemod/scripting/ne/menus.inc
+++ b/addons/sourcemod/scripting/ne/menus.inc
@@ -127,31 +127,27 @@ bool PopulateNominateListMenu(Menu menu, int client, const char[] filter = "")
 		return false;
 	}
 
-	bool restrictionsActive = AreRestrictionsActive();
-
 	static char map[PLATFORM_MAX_PATH];
 	static char display[PLATFORM_MAX_PATH];
+	static char description[PLATFORM_MAX_PATH];
 	for (int i = 0; i < GetArraySize(MapList); i++)
 	{
 		GetArrayString(MapList, i, map, sizeof(map));
 
 		if (!filter[0] || StrContains(map, filter, false) != -1)
 		{
-			strcopy(display, sizeof(display), map);
+			MCE_GetMapDescription(map, description, sizeof(description));
+			MCE_GetMapDisplayName(map, display, sizeof(display));
 
-			bool adminRestriction = IsClientMapAdminRestricted(map);
-			if ((adminRestriction) && restrictionsActive)
-				Format(display, sizeof(display), "%s (%T)", display, "Admin Nomination", client);
+			if (description[0] != '\0')
+				Format(display, sizeof(display), "%s | %s", display, description);
 
-			bool VIPRestriction = IsClientMapVIPRestricted(map);
-			if ((VIPRestriction) && restrictionsActive)
-				Format(display, sizeof(display), "%s (%T)", display, "VIP Nomination", client);
-
-			#if defined _zleader_included
-			bool LeaderRestriction = IsClientMapLeaderRestricted(map);
-			if ((LeaderRestriction) && restrictionsActive)
-				Format(display, sizeof(display), "%s (%T)", display, "Leader Nomination", client);
-			#endif
+			// Add restriction badges if any
+			char badgeBuffer[100];
+			if (FormatMapRestrictionBadgesDetailed(map, client, badgeBuffer, sizeof(badgeBuffer), true))
+			{
+				Format(display, sizeof(display), "%s %s", display, badgeBuffer);
+			}
 
 			int owner = GetArrayCell(OwnerList, i);
 
@@ -246,12 +242,20 @@ Menu BuildMapMenu(const char[] filter, int client = -1)
 
 	tempMapList.SortCustom(AlphabeticSortCallback);
 
+	static char display[PLATFORM_MAX_PATH];
+	static char description[PLATFORM_MAX_PATH];
 	for (int i = 0; i < tempMapList.Length; i++)
 	{
 		tempMapList.GetString(i, map, sizeof(map));
-		AddMenuItem(menu, map, map);
+		MCE_GetMapDescription(map, description, sizeof(description));
+		MCE_GetMapDisplayName(map, display, sizeof(display));
+
+		if (description[0] != '\0')
+			Format(display, sizeof(display), "%s | %s", display, description);
+
+		AddMenuItem(menu, map, display);
 	}
-	
+
 	delete tempMapList;
 	SetMenuExitButton(menu, true);
 
@@ -288,11 +292,19 @@ Menu BuildAdminMapMenu(const char[] filter)
 	// Sort the maps in alphabetical order
 	tempMapList.SortCustom(AlphabeticSortCallback);
 	
+	static char display[PLATFORM_MAX_PATH];
+	static char description[PLATFORM_MAX_PATH];
 	// Add the maps to the menu
 	for (int i = 0; i < tempMapList.Length; i++)
 	{
 		tempMapList.GetString(i, map, sizeof(map));
-		AddMenuItem(menu, map, map);
+		MCE_GetMapDescription(map, description, sizeof(description));
+		MCE_GetMapDisplayName(map, display, sizeof(display));
+
+		if (description[0] != '\0')
+			Format(display, sizeof(display), "%s | %s", display, description);
+
+		AddMenuItem(menu, map, display);
 	}
 
 	delete tempMapList;
@@ -435,6 +447,14 @@ public int Handler_MapSelectMenu(Menu menu, MenuAction action, int param1, int p
 
 			static char buffer[100];
 			static char display[150];
+			static char displayName[PLATFORM_MAX_PATH];
+			static char description[PLATFORM_MAX_PATH];
+
+			MCE_GetMapDescription(map, description, sizeof(description));
+			MCE_GetMapDisplayName(map, displayName, sizeof(displayName));
+
+			if (description[0] != '\0')
+				Format(displayName, sizeof(displayName), "%s | %s", displayName, description);
 
 			if (mark)
 				official = IsMapOfficial(map);
@@ -445,37 +465,17 @@ public int Handler_MapSelectMenu(Menu menu, MenuAction action, int param1, int p
 				{
 					case 1:
 					{
-						Format(buffer, sizeof(buffer), "%T", "Custom Marked", param1, map);
+						Format(buffer, sizeof(buffer), "%T", "Custom Marked", param1, displayName);
 					}
 
 					case 2:
 					{
-						Format(buffer, sizeof(buffer), "%T", "Custom", param1, map);
+						Format(buffer, sizeof(buffer), "%T", "Custom", param1, displayName);
 					}
 				}
 			}
 			else
-				strcopy(buffer, sizeof(buffer), map);
-
-			bool adminRestriction = IsClientMapAdminRestricted(map);
-			if (restrictionsActive && adminRestriction)
-			{
-				Format(buffer, sizeof(buffer), "%s (%T)", buffer, "Admin Restriction", param1);
-			}
-
-			bool VIPRestriction = IsClientMapVIPRestricted(map);
-			if (restrictionsActive && VIPRestriction)
-			{
-				Format(buffer, sizeof(buffer), "%s (%T)", buffer, "VIP Restriction", param1);
-			}
-
-			#if defined _zleader_included
-			bool LeaderRestriction = IsClientMapLeaderRestricted(map);
-			if (restrictionsActive && LeaderRestriction)
-			{
-				Format(buffer, sizeof(buffer), "%s (%T)", buffer, "Leader Restriction", param1);
-			}
-			#endif
+				strcopy(buffer, sizeof(buffer), displayName);
 
 			int status;
 			if (GetTrieValue(g_mapTrie, map, status))
@@ -513,49 +513,17 @@ public int Handler_MapSelectMenu(Menu menu, MenuAction action, int param1, int p
 				return RedrawMenuItem(display);
 			}
 
-			int TimeRestriction = GetMapTimeRestriction(map);
-			if (restrictionsActive && TimeRestriction)
+			// Format restriction badges + Check if we have any badges to display
+			bool hasBadges;
+			char badgeBuffer[100];
+			if (FormatMapRestrictionBadgesDetailed(map, param1, badgeBuffer, sizeof(badgeBuffer), false))
 			{
-				Format(display, sizeof(display), "%s (%T)", buffer, "Map Time Restriction", param1, "+", TimeRestriction / 60, TimeRestriction % 60);
-				return RedrawMenuItem(display);
+				Format(buffer, sizeof(buffer), "%s %s", buffer, badgeBuffer);
+				hasBadges = true;
 			}
 
-			int PlayerRestriction = GetMapPlayerRestriction(map);
-			if (restrictionsActive && PlayerRestriction)
-			{
-				if (PlayerRestriction < 0)
-					Format(display, sizeof(display), "%s (%T)", buffer, "Map Player Restriction", param1, "+", PlayerRestriction * -1);
-				else
-					Format(display, sizeof(display), "%s (%T)", buffer, "Map Player Restriction", param1, "-", PlayerRestriction);
-
-				return RedrawMenuItem(display);
-			}
-
-			int GroupRestriction = GetMapGroupRestriction(map, param1);
-			if (restrictionsActive && GroupRestriction >= 0)
-			{
-				Format(display, sizeof(display), "%s (%T)", buffer, "Map Group Restriction", param1, GroupRestriction);
-				return RedrawMenuItem(display);
-			}
-
-			if (restrictionsActive && adminRestriction)
-			{
-				return RedrawMenuItem(buffer);
-			}
-
-			if (restrictionsActive && VIPRestriction)
-			{
-				return RedrawMenuItem(buffer);
-			}
-
-			#if defined _zleader_included
-			if (restrictionsActive && LeaderRestriction)
-			{
-				return RedrawMenuItem(buffer);
-			}
-			#endif
-
-			if (mark && !official)
+			// If we have badges or custom mark, return the formatted buffer
+			if (hasBadges || (mark && !official))
 				return RedrawMenuItem(buffer);
 
 			return 0;
@@ -654,4 +622,89 @@ public int Handler_AdminRemoveMapMenu(Menu menu, MenuAction action, int param1, 
 	}
 
 	return 0;
+}
+
+bool FormatMapRestrictionBadgesDetailed(const char[] map, int client, char[] buffer, int maxlength, bool nominatedlist = false)
+{
+	bool restrictionsActive = AreRestrictionsActive();
+
+	// If map is recently played, don't show badges (it's not nominable anyway)
+	int cooldownTime = GetMapCooldownTime(map);
+	if (restrictionsActive && cooldownTime > GetTime())
+		return false;
+
+	bool hasBadges = false;
+	char badges[200];
+
+	if (restrictionsActive)
+	{
+		bool adminRestriction = IsClientMapAdminRestricted(map);
+		if (adminRestriction)
+		{
+			Format(badges, sizeof(badges), "%s%T|", badges, "Admin Restriction", client);
+			hasBadges = true;
+		}
+
+		bool VIPRestriction = IsClientMapVIPRestricted(map);
+		if (VIPRestriction)
+		{
+			Format(badges, sizeof(badges), "%s%T|", badges, "VIP Restriction", client);
+			hasBadges = true;
+		}
+
+		#if defined _zleader_included
+		bool LeaderRestriction = IsClientMapLeaderRestricted(map);
+		if (LeaderRestriction)
+		{
+			Format(badges, sizeof(badges), "%s%T|", badges, "Leader Restriction", client);
+			hasBadges = true;
+		}
+		#endif
+
+		if (!nominatedlist)
+		{
+			// Time restriction with value
+			int timeRestriction = GetMapTimeRestriction(map);
+			if (timeRestriction > 0)
+			{
+				Format(badges, sizeof(badges), "%s%T|", badges, "Map Time Restriction", client, "+", timeRestriction / 60, timeRestriction % 60);
+				hasBadges = true;
+			}
+
+			// Player restriction with value
+			int playerRestriction = GetMapPlayerRestriction(map);
+			if (playerRestriction != 0)
+			{
+				if (playerRestriction < 0)
+						Format(badges, sizeof(badges), "%s%T|", buffer, "Map Player Restriction", client, "+", playerRestriction * -1);
+					else
+						Format(badges, sizeof(badges), "%s%T|", buffer, "Map Player Restriction", client, "-", playerRestriction);
+				hasBadges = true;
+			}
+
+			// Group restriction with value
+			int groupRestriction = GetMapGroupRestriction(map, client);
+			if (groupRestriction >= 0)
+			{
+				Format(badges, sizeof(badges), "%s%T|", badges, "Map Group Restriction", client, groupRestriction);
+				hasBadges = true;
+			}
+		}
+	}
+
+	if (hasBadges)
+	{
+		// Remove trailing |
+		int len = strlen(badges);
+		if (len > 0 && badges[len-1] == '|')
+		{
+			badges[len-1] = '\0';
+		}
+
+		// Format with brackets
+		Format(buffer, maxlength, "[%s]", badges);
+		return true;
+	}
+
+	return false;
 }


### PR DESCRIPTION
- Introduces native functions and internal helpers to retrieve map descriptions and display names.
- Updates menus and command output to show these details, along with restriction badges, improving map information visibility throughout the plugin.
- Also bumps patch versions for mapchooser_extended and nominations_extended includes.